### PR TITLE
STORY-3: Remove unused tables

### DIFF
--- a/Backend/migrations/20250207173237-drop-unused-tables.js
+++ b/Backend/migrations/20250207173237-drop-unused-tables.js
@@ -1,0 +1,14 @@
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // If you want to drop them:
+    await queryInterface.dropTable('collaborator_audit');
+    await queryInterface.dropTable('project_status_history');
+    await queryInterface.dropTable('role_attributes');
+    await queryInterface.dropTable('roles');
+  },
+  async down(queryInterface, Sequelize) {
+    // If you want a down method, you'd recreate them 
+    // with the same structure, but you probably won't need that 
+    // unless you might roll back.
+  }
+};

--- a/backend_aggregated.txt
+++ b/backend_aggregated.txt
@@ -3290,9 +3290,9 @@ app.get('/api/protected', authMiddleware, (req, res) => {
 });
 
 // Database synchronization
-db.sequelize.sync({ alter: true })
-    .then(() => logger.info('Database synced successfully'))
-    .catch(err => logger.error('Database sync error:', err));
+//db.sequelize.sync({ alter: true })
+   // .then(() => logger.info('Database synced successfully'))
+   // .catch(err => logger.error('Database sync error:', err));
 
 // Use the centralized error handling middleware (should be after all routes)
 app.use(errorHandler);


### PR DESCRIPTION
Story 3 sprint 1
Decided to remove the unused tables in favour of creating new ones through migration when the need arises. 
Migration file: 20250207173237-drop-unused-tables.js used to remove tables. 